### PR TITLE
Adding OpenSSL to the nightly/lint image

### DIFF
--- a/nightly/lint/Dockerfile
+++ b/nightly/lint/Dockerfile
@@ -1,3 +1,9 @@
 FROM rustlang/rust:nightly-slim
 
 RUN rustup component add rustfmt-preview clippy-preview
+
+# Install OpenSSL - see https://github.com/sfackler/rust-openssl
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y pkg-config libssl-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Allow projects which have a dependency on OpenSSL to build.